### PR TITLE
Fixed missing javax.xml.bind and uk.ac.shef.wit Repository URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,11 +118,16 @@
     <repositories>
        <repository>
            <id>uk.ac.shef.wit</id>
-           <url>http://maven.mse.jhu.edu/m2repository/</url>
+           <url>https://dev-iesl.cs.umass.edu/nexus/content/repositories/releases/</url>
        </repository>
     </repositories>
  
     <dependencies>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.1</version>
+        </dependency>
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>


### PR DESCRIPTION
OpenID-Attacker can now be builds on systems with Java 11.